### PR TITLE
Registrierung der moodle app in das edu-sharing-repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+.history

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Dieses Projekt bietet die Möglichkeit, ein edu-sharing mit minimalem Aufwand in einer virtuellen Maschine aufzusetzen. Voraussetzung ist die Installation von
 [Git](https://git-scm.com/downloads),  [Vagrant](https://www.vagrantup.com/downloads.html) und [VirtualBox](https://www.virtualbox.org/wiki/Downloads).
 
+Außerdem kann eine Moodle-Instanz an das Repositorium angebunden werden. Siehe hierfür [Moodle-Integration](#moodle-integration)
+
 ## Installation
 
 Die folgenden Schritte im Terminal (Linux/macOS) oder in der GitBash (Windows) ausführen.
@@ -35,3 +37,11 @@ vagrant ssh
 * Update Notes prüfen unter https://docs.edu-sharing.com/confluence/edp/en/updating-en/updating-the-rendering-service und ggf. Prozess anpassen
 * *esrender_version* anpassen in den renderingservice-vars
 * playbook ausführen
+
+## Moodle Integration
+
+- zunächst Edu-Sharing-Box wie in [Installation](#installation) geschildert installieren
+- nach erfolgreicher Installation die [Moodle-Box](https://github.com/TIBHannover/moodle-box) installieren. Dabei darauf achten, dass im Vagrantfile `ansible.skip_tags = [ "edu-sharing-plugin" ]` auskommentiert ist, damit das Plugin installiert wird
+- anschließend im Vagrantfile der Edu-Sharing-Box die Auskommentierung von `ansible.skip_tags = [ "moodle-registration" ]` entfernen
+- im edu-sharing-box-Verzeichnis den Befehl `vagrant reload --provision`ausführen
+- nun sollte in moodle eine Einbindung des edu-sharing Repositoriums erfolgt sein

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure("2") do |config|
     ansible.install = true
     ansible.install_mode = "pip"
     # Vagrant 2.2.5: fix pip installation by uncommenting the next line (see https://github.com/hashicorp/vagrant/issues/10950)
-    #ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/get-pip.py | sudo python"
+    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/get-pip.py | sudo python"
     ansible.version = "latest"
 #  config.vm.provision "ansible" do |ansible|
     ansible.compatibility_mode = "2.0"
@@ -50,5 +50,6 @@ Vagrant.configure("2") do |config|
         "timezone" => "Europe/Berlin"
       }
     }
+    ansible.skip_tags = [ "moodle-registration" ]
   end
 end

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -23,3 +23,6 @@ base_dir: "{{ansible_env.HOME}}"
 esrender_document_root: '/var/www'
 esrender_base_dir: '{{esrender_document_root}}/esrender'
 esrender_cache_dir: '/var/cache/esrender'
+
+moodle_host: 192.168.98.105
+moodle_url: "http://{{moodle_host}}"

--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -11,10 +11,10 @@ youtube_apikey: CHANGE_ME
 
 #edu_version: 4.1.7
 edu_version: 4.1.8
-#edu_version: 4.2.2
+# edu_version: 4.2.2
 #edu_sharing_archive_url: https://github.com/edu-sharing/Edu-Sharing/releases/download/4.1.7/edu-sharing_4.1.7.2019-05-15-9ca4a3a2.zip
 edu_sharing_archive_url: https://github.com/edu-sharing/Edu-Sharing/releases/download/4.1.8/edu-sharing_4.1.8.2019-07-29-b7fa22d8.zip
-#edu_sharing_archive_url: https://github.com/edu-sharing/Edu-Sharing/releases/download/4.2.2/edu-sharing_4.2.2.2019-07-23-5a3bfb26.zip
+# edu_sharing_archive_url: https://github.com/edu-sharing/Edu-Sharing/releases/download/4.2.2/edu-sharing_4.2.2.2019-07-23-5a3bfb26.zip
 
 edu_inst_dir: "{{base_dir}}/edu-sharing_{{edu_version}}"
 edu_home: "{{edu_inst_dir}}/edu-sharing"

--- a/ansible/group_vars/renderingservice.yml
+++ b/ansible/group_vars/renderingservice.yml
@@ -2,6 +2,6 @@
 esrender_vhost: true
 
 esrender_version: 4.1.11
-#esrender_version: 4.2.1
+# esrender_version: 4.2.1
 esrender_archive_url: 'https://github.com/edu-sharing/renderingservice/archive/{{esrender_version}}.tar.gz'
 esrender_download_dir: "{{base_dir}}/esrender_{{esrender_version}}"

--- a/ansible/roles/moodle-registration/tasks/main.yml
+++ b/ansible/roles/moodle-registration/tasks/main.yml
@@ -1,0 +1,115 @@
+---
+# Register the Moodle App in esrepo
+- name: Ensure necessary packages are present
+  apt:
+    name: '{{ packages }}'
+    state: present
+  become: yes
+  vars:
+    packages:
+      - python-lxml
+  tags:
+  - packages
+  - root-task
+
+- name: get moodle metadata info
+  uri:
+    url: '{{ moodle_url }}/mod/edusharing/metadata.php'
+    method: GET
+    return_content: yes
+  register: moodle_meta
+
+- name: get moodle appid
+  xml:
+    xmlstring: "{{moodle_meta.content}}"
+    xpath: /properties/entry[@key='appid']
+    content: 'text'
+  register: moodle_appid
+
+- name: get moodle type
+  xml:
+    xmlstring: "{{moodle_meta.content}}"
+    xpath: /properties/entry[@key='type']
+    content: 'text'
+  register: moodle_type
+
+- name: get moodle subtype
+  xml:
+    xmlstring: "{{moodle_meta.content}}"
+    xpath: /properties/entry[@key='subtype']
+    content: 'text'
+  register: moodle_subtype
+
+- name: get moodle domain
+  xml:
+    xmlstring: "{{moodle_meta.content}}"
+    xpath: /properties/entry[@key='domain']
+    content: 'text'
+  register: moodle_domain
+
+- name: get moodle host
+  xml:
+    xmlstring: "{{moodle_meta.content}}"
+    xpath: /properties/entry[@key='host']
+    content: 'text'
+  register: moodle_host
+
+- name: get moodle trustedclient
+  xml:
+    xmlstring: "{{moodle_meta.content}}"
+    xpath: /properties/entry[@key='trustedclient']
+    content: 'text'
+  register: moodle_trustedclient
+
+- name: get moodle hasTeachingPermission
+  xml:
+    xmlstring: "{{moodle_meta.content}}"
+    xpath: /properties/entry[@key='hasTeachingPermission']
+    content: 'text'
+  register: moodle_hasTeachingPermission
+
+- name: get moodle public_key
+  xml:
+    xmlstring: "{{moodle_meta.content}}"
+    xpath: /properties/entry[@key='public_key']
+    content: 'text'
+  register: moodle_public_key
+
+- name: get moodle appcaption
+  xml:
+    xmlstring: "{{moodle_meta.content}}"
+    xpath: /properties/entry[@key='appcaption']
+    content: 'text'
+  register: moodle_appcaption
+
+# Stop and start alfresco later to recognize changes
+- name: stop alfresco
+  shell: '{{tomcat_stop_command}}'
+
+- name: Copy app-moodle.properties.xml to tomcat
+  template:
+    src: app-moodle.properties.xml.j2
+    dest: '{{tomcat_home}}/shared/classes/app-moodle.properties.xml'
+    mode: 0644
+
+- name: Add moodle-app in ccapp-registry.properties.xml
+  xml:
+    path: '{{tomcat_home}}/shared/classes/ccapp-registry.properties.xml'
+    xpath: /properties/entry[@key='applicationfiles']
+    content: 'text'
+  register: current_applicationfiles
+
+- name: Set up a string variable
+  set_fact:
+    updated_applicationfiles_with_moodle: "{{current_applicationfiles.matches[0]['entry'] + ',app-moodle.properties.xml' }}"
+  when: "'app-moodle.properties.xml' not in current_applicationfiles.matches"
+
+- name: Copy ccapp-registry.properties.xml to tomcat
+  template:
+    src: ccapp-registry.properties.xml.j2
+    dest: '{{tomcat_home}}/shared/classes/ccapp-registry.properties.xml'
+    mode: 0644
+  when: "'app-moodle.properties.xml' not in current_applicationfiles.matches[0]['entry']"
+
+- name: start alfresco
+  shell: '{{tomcat_start_command}}'

--- a/ansible/roles/moodle-registration/templates/app-moodle.properties.xml.j2
+++ b/ansible/roles/moodle-registration/templates/app-moodle.properties.xml.j2
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+  <comment/>
+  <entry key="appcaption">{{moodle_appcaption.matches[0]['entry'] }}</entry>
+  <entry key="public_key">{{moodle_public_key.matches[0]['entry'] }}</entry>
+  <entry key="domain">{{moodle_domain.matches[0]['entry'] }}</entry>
+  <entry key="trustedclient">{{moodle_trustedclient.matches[0]['entry'] }}</entry>
+  <entry key="subtype">{{moodle_subtype.matches[0]['entry'] }}</entry>
+  <entry key="type">{{moodle_type.matches[0]['entry'] }}</entry>
+  <entry key="hasTeachingPermission">{{moodle_hasTeachingPermission.matches[0]['entry'] }}</entry>
+  <entry key="appid">{{moodle_appid.matches[0]['entry'] }}</entry>
+  <entry key="host">{{moodle_host.matches[0]['entry'] }}</entry>
+</properties>
+

--- a/ansible/roles/moodle-registration/templates/ccapp-registry.properties.xml.j2
+++ b/ansible/roles/moodle-registration/templates/ccapp-registry.properties.xml.j2
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>Thu Aug 15 14:02:22 CEST 2019 added file:app-moodle_ansible_plugin.properties.xml</comment>
+<entry key="applicationfiles">{{ updated_applicationfiles_with_moodle }}</entry>
+</properties>

--- a/ansible/system.yml
+++ b/ansible/system.yml
@@ -36,3 +36,9 @@
     - edu-sharing
     - renderingservice-init
     - renderingservice-registration
+
+- hosts: edusharing
+  roles:
+    - moodle-registration
+  tags:
+    - moodle-registration


### PR DESCRIPTION
Hallo zusammen,

ich habe hier die Möglichkeit der Registrierung der moodle-app in das edu-sharing Repositorium eingefügt (Zeilenangaben beziehen sich auf moodle-registration/tasks/main.yml): 

- zunächst werden die Metadaten der Moodleapp ausgelesen (15-83)
- anschließend wird die App im edu-sharing Repo mit den files app-moodle.properties.xml und ccapp-registry.properties.xml registriert (89-112)
- dann alfresco neu gestartet, um die Änderungen mitzubekommen

Der Rest sind nur kleinere Änderungen.
