### PR TITLE
use postgresql instead of mariadb

### DIFF
--- a/ansible/group_vars/alfresco.yml
+++ b/ansible/group_vars/alfresco.yml
@@ -1,5 +1,6 @@
 ---
 mysql_jconnector_url: https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar
+postgresql_jconnector_url: https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.8/postgresql-42.2.8.jar
 
 alf_sources_url: 'https://process.alfresco.com/ccdl/?file=release/community/5.0.d-build-00002/{{alf_name}}.zip'
 alf_password: admin
@@ -8,6 +9,8 @@ alf_name: alfresco-community-5.0.d
 alf_inst_dir: "{{base_dir}}"
 alf_home: "{{alf_inst_dir}}/{{alf_name}}"
 
+# db_types: 'postgresql', 'mariadb' (edu-sharing 4.2 supports only 'postgresql', no migration on change)
+alfresco_db_type: postgresql
 alfresco_db:
   name: alfresco
   user: alfresco

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -8,10 +8,15 @@ esrender_host: 192.168.98.102
 esrender_url: 'http://{{esrender_host}}/esrender'
 
 mariadb_port: 3306
+postgresql_port: 5432
+# db_types: 'postgresql', 'mariadb' (no migration on change)
+esrender_db_type: postgresql
 esrender_db:
   name: esrender
   user: esrender
   password: esrender
+  
+postgres_tmp_root_password: xxx
 
 tomcat_port: 8080
 tomcat_shutdown_port: 8005

--- a/ansible/roles/edu-sharing/tasks/alfresco.yml
+++ b/ansible/roles/edu-sharing/tasks/alfresco.yml
@@ -20,6 +20,14 @@
     url: '{{mysql_jconnector_url}}'
     dest: "{{tomcat_home}}/lib/mysql-connector-java.jar"
     force: yes # necessary for driver updates
+  when: alfresco_db_type == 'mariadb'
+
+- name: download postgres jconnector
+  get_url:
+    url: '{{postgresql_jconnector_url}}'
+    dest: "{{tomcat_home}}/lib/postgresql.jar"
+    force: yes # necessary for driver updates
+  when: alfresco_db_type == 'postgresql'
 
 - name: download alfresco sources
   get_url:
@@ -67,7 +75,7 @@
 
 - name: Configure alfresco-global.properties
   template:
-    src: alfresco-global.properties
+    src: alfresco-global.properties.j2
     dest: '{{tomcat_home}}/shared/classes/alfresco-global.properties'
 
 - name: Ensure python-lxml packages are present

--- a/ansible/roles/edu-sharing/tasks/main.yml
+++ b/ansible/roles/edu-sharing/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
   - include: mariadb.yml
+    when: alfresco_db_type == 'mariadb'
+  - include: postgresql.yml
+    when: alfresco_db_type == 'postgresql'
   - include: imagemagick.yml
   - include: libreoffice.yml
   - include: alfresco.yml

--- a/ansible/roles/edu-sharing/tasks/postgresql.yml
+++ b/ansible/roles/edu-sharing/tasks/postgresql.yml
@@ -1,0 +1,49 @@
+---
+- name: Ensure postgres python packages are present
+  package:
+    name: python-psycopg2
+  become: yes
+  tags:
+  - packages
+  - root-task
+
+# postgres requires commands (like db creation) to be executed as local user 'postgres' per default
+# -> we are not able to use this procedure, because of the 'become unpriv user problem' in ansible
+# switching the auth-method from peer is no option either
+# -> our procedure: set postgres-pw for db configurationo and remove afterwards
+- name: Set postgres password
+  become: yes
+  shell: 'su postgres -c "psql --command=\"ALTER USER postgres WITH PASSWORD ''{{postgres_tmp_root_password}}'';\""'
+  tags:
+  - packages
+  - root-task
+
+- name: Create a new database with name 'alfresco'
+  postgresql_db:
+    login_password: '{{postgres_tmp_root_password}}'
+    login_host: localhost
+    name: '{{alfresco_db.name}}'
+    encoding: 'utf8'
+    state: present
+  become: yes
+  tags:
+  - root-task
+
+- name: Create alfesco database user
+  postgresql_user:
+    login_password: '{{postgres_tmp_root_password}}'
+    login_host: localhost
+    db: '{{alfresco_db.name}}'
+    name: '{{alfresco_db.user}}'
+    password: '{{alfresco_db.password}}'
+    priv: 'ALL'
+  become: yes
+  tags:
+  - root-task
+
+- name: remove postgres password
+  become: yes
+  shell: 'su postgres -c "psql --command=\"ALTER USER postgres WITH PASSWORD null;\""'
+  tags:
+  - packages
+  - root-task

--- a/ansible/roles/edu-sharing/templates/alfresco-global.properties.j2
+++ b/ansible/roles/edu-sharing/templates/alfresco-global.properties.j2
@@ -8,9 +8,14 @@ dir.keystore=${dir.root}/keystore
 # database connection properties
 db.username={{alfresco_db.user}}
 db.password={{alfresco_db.password}}
+{% if alfresco_db_type == 'postgresql' %}
+db.driver=org.postgresql.Driver
+db.url=jdbc:postgresql://localhost:{{postgresql_port}}/{{alfresco_db.name}}
+{% elif alfresco_db_type == 'mariadb' %}
 db.driver=com.mysql.jdbc.Driver
 db.url=jdbc:mysql://localhost/{{alfresco_db.name}}?useUnicode=yes&characterEncoding=UTF-8
 hibernate.dialect=org.hibernate.dialect.MySQLInnoDBDialect
+{% endif %}
 
 index.subsystem.name=solr4
 # TODO solr host have to be configured first: allow access from alfresco host

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Install PostgreSQL server package
+  package:
+    name: postgresql
+    state: present
+  tags:
+  - packages
+  - root-task
+  

--- a/ansible/roles/renderingservice-init/tasks/main.yml
+++ b/ansible/roles/renderingservice-init/tasks/main.yml
@@ -44,7 +44,28 @@
       DB_PASS: '{{esrender_db.password}}'
       DB_NAME: '{{esrender_db.name}}'
       send: ''
-  when: "esrender_init_meta['status'] == 500"
+  when: "esrender_init_meta['status'] == 500 and esrender_db_type == 'mariadb'"
+
+- name: esrender installation step 2
+  uri:
+    url: '{{esrender_url}}/install/install.php'
+    method: POST
+    body_format: form-urlencoded
+    body:
+      step: 2
+      LANG: 1
+      RS_URL: '{{esrender_url}}/'
+      BASE_DIR: '{{esrender_base_dir}}/'
+      DATA_DIR: '{{esrender_cache_dir}}/'
+      REPO_URL: 'http://{{edu_sharing_host}}/edu-sharing/'
+      DB_DRIVER: pgsql
+      DB_HOST: 127.0.0.1
+      DB_PORT: '{{postgresql_port}}'
+      DB_USER: '{{esrender_db.user}}'
+      DB_PASS: '{{esrender_db.password}}'
+      DB_NAME: '{{esrender_db.name}}'
+      send: ''
+  when: "esrender_init_meta['status'] == 500 and esrender_db_type == 'postgresql'"
 
 - name: esrender installation step 3
   uri:

--- a/ansible/roles/renderingservice-installation/tasks/main.yml
+++ b/ansible/roles/renderingservice-installation/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
   - include: mariadb.yml
+    when: esrender_db_type == 'mariadb'
+  - include: postgresql.yml
+    when: esrender_db_type == 'postgresql'
   - include: esrender.yml

--- a/ansible/roles/renderingservice-installation/tasks/postgresql.yml
+++ b/ansible/roles/renderingservice-installation/tasks/postgresql.yml
@@ -1,0 +1,49 @@
+---
+- name: Ensure postgres python packages are present
+  package:
+    name: python-psycopg2
+  become: yes
+  tags:
+  - packages
+  - root-task
+
+# postgres requires commands (like db creation) to be executed as local user 'postgres' per default
+# -> we are not able to use this procedure, because of the 'become unpriv user problem' in ansible
+# switching the auth-method from peer is no option either
+# -> our procedure: set postgres-pw for db configurationo and remove afterwards
+- name: Set postgres password
+  become: yes
+  shell: 'su postgres -c "psql --command=\"ALTER USER postgres WITH PASSWORD ''{{postgres_tmp_root_password}}'';\""'
+  tags:
+  - packages
+  - root-task
+
+- name: Create a new database with name 'esrender'
+  postgresql_db:
+    login_password: '{{postgres_tmp_root_password}}'
+    login_host: localhost
+    name: '{{esrender_db.name}}'
+    encoding: 'utf8'
+    state: present
+  become: yes
+  tags:
+  - root-task
+
+- name: Create esrender database user
+  postgresql_user:
+    login_password: '{{postgres_tmp_root_password}}'
+    login_host: localhost
+    db: '{{esrender_db.name}}'
+    name: '{{esrender_db.user}}'
+    password: '{{esrender_db.password}}'
+    priv: 'ALL'
+  become: yes
+  tags:
+  - root-task
+
+- name: remove postgres password
+  become: yes
+  shell: 'su postgres -c "psql --command=\"ALTER USER postgres WITH PASSWORD null;\""'
+  tags:
+  - packages
+  - root-task

--- a/ansible/system.yml
+++ b/ansible/system.yml
@@ -10,13 +10,26 @@
   become: yes
   roles:
     - apache
-    - mariadb
+  tags:
+    - root-task
+
+- hosts: edusharing
+  become: yes
+  roles:
+    - role: postgresql
+      when: alfresco_db_type == 'postgresql'
+    - role: mariadb
+      when: alfresco_db_type == 'mariadb'
   tags:
     - root-task
 
 - hosts: renderingservice
   become: yes
   roles:
+    - role: postgresql
+      when: esrender_db_type == 'postgresql'
+    - role: mariadb
+      when: esrender_db_type == 'mariadb'
     - renderingservice-installation
   tags:
     - root-task


### PR DESCRIPTION
Da edu-sharing ab Version 4.2 MySQL für das Repo nicht mehr unterstützt, sollten wir auf postgresql wechseln.

Welche DB verwendet wird, wird in den Properties definiert.

Bei einem Wechsel werden keine Daten einer evtl bestehenden DB migriert.