### PR TITLE
Added possibility to install splash and configure splash-preview in es

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,6 +39,7 @@ Vagrant.configure("2") do |config|
     ansible.compatibility_mode = "2.0"
     #ansible.verbose = "vvv"
     ansible.playbook = "ansible/system.yml"
+    ansible.galaxy_role_file = "requirements.yml"
     ansible.groups = {
       "alfrescosolr4" => ["edu-sharing-vm"],
       "edusharing" => ["edu-sharing-vm"],

--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -58,6 +58,7 @@ edu_mail_smtp_port: 25
 # the sender address used to send mails
 edu_mail_smtp_from: pleasechange@nodomain.com
 
+edu_splash_url: # "http://{{ esrender_host }}:8050/render.png" # URL of the splash-service for http previews
 edu_imprinturl:
 edu_privacyInformationUrl:
 edu_workspace_viewType:   # 'tile' | 'list'

--- a/ansible/group_vars/renderingservice.yml
+++ b/ansible/group_vars/renderingservice.yml
@@ -19,3 +19,5 @@ esrender_exec_method: http
 #  'copy-local' - copy the archive from the local host in 'esrender_local_archive_path'
 esrender_archive_retrieve_method: download
 esrender_local_archive_path:
+
+install_splash: false # install splash on renderingservice-hosts - see https://splash.readthedocs.io/en/stable/index.html

--- a/ansible/roles/edu-sharing/templates/edu-sharing.conf.j2
+++ b/ansible/roles/edu-sharing/templates/edu-sharing.conf.j2
@@ -7,4 +7,11 @@ repository: {
             enabled:{{ edu_enable_statistics_api }}
         }
     }
+{% if edu_splash_url is defined and edu_splash_url is not none and edu_splash_url != "" %}
+    communication:{
+        splash:{
+            url: "{{ edu_splash_url }}"
+        }
+    }
+{% endif %}
 }

--- a/ansible/roles/splash/defaults/main.yml
+++ b/ansible/roles/splash/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+splash_port: 8050
+docker_users:
+  - "{{ ansible_user }}"

--- a/ansible/roles/splash/tasks/main.yml
+++ b/ansible/roles/splash/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Stop running docker-container, if exists
+  shell: "sg docker -c \"docker ps --format '{{ '{{' }}.Image{{ '}}' }}' | grep -q 'scrapinghub/splash' && docker stop splash\""
+  ignore_errors: yes  # exit code 1, if container does not exist
+
+- name: Remove docker-container, if exists
+  shell: "sg docker -c \"docker ps -a --format '{{ '{{' }}.Image{{ '}}' }}' | grep -q 'scrapinghub/splash' && docker rm splash\""
+  ignore_errors: yes  # exit code 1, if container does not exist
+
+- name: Run splash docker-container
+  shell: "sg docker -c \"docker run --name splash --restart=always -d -p {{ splash_port }}:8050 scrapinghub/splash\""

--- a/ansible/system.yml
+++ b/ansible/system.yml
@@ -48,6 +48,10 @@
     - role: mariadb
       when: esrender_db_type == 'mariadb'
     - renderingservice-installation
+    - role: geerlingguy.docker
+      when: install_splash is defined and install_splash
+    - role: splash
+      when: install_splash is defined and install_splash
   tags:
     - root-task
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: geerlingguy.docker
+  version: 4.0.0


### PR DESCRIPTION
* install splash (https://splash.readthedocs.io/en/stable/index.html) via docker an renderingservice hosts
    * -> ansible var `install_splash: true`
* configure usage of splash in edu-sharing
    * -> ansible var `edu_splash_url: "http://{{ esrender_host }}:8050/render.png"`