### PR TITLE
Fix copy configuration files for esrender

### DIFF
--- a/ansible/group_vars/renderingservice.yml
+++ b/ansible/group_vars/renderingservice.yml
@@ -21,3 +21,7 @@ esrender_archive_retrieve_method: download
 esrender_local_archive_path:
 
 install_splash: false # install splash on renderingservice-hosts - see https://splash.readthedocs.io/en/stable/index.html
+
+#  a list of configuration files for esrender
+esrender_custom_config_files:
+  # - ["config.php.j2","office/config.php"]

--- a/ansible/roles/renderingservice-installation/tasks/esrender.yml
+++ b/ansible/roles/renderingservice-installation/tasks/esrender.yml
@@ -66,7 +66,7 @@
     - restart apache2
 
 - name: Copy custom configuration files for esrender application
-  copy:
+  template:
     src: '{{item[0]}}'
     dest: '{{ esrender_base_dir }}/modules/{{item[1]}}'
   loop: '{{ esrender_custom_config_files | default([], true) }}'


### PR DESCRIPTION
Hello @mirjan-hoffmann 

since we need to add variables in configuration files (config.php), I change the task from copy to template, so we can set variables, before we copy those files, 

and also I add the variable `esrender_custom_config_files`, looks like is deleted somehow from last pullrequest (small change).


best regards
Edmond