### PR TITLE
Remove some plugins from gstream, since they they have security issues

### DIFF
--- a/ansible/roles/edu-sharing/tasks/libreoffice.yml
+++ b/ansible/roles/edu-sharing/tasks/libreoffice.yml
@@ -6,3 +6,9 @@
     tags:
     - packages
     - root-task
+
+  - name: Remove gst-plugins-bad, since they have security issues 
+    apt:
+      name: ['libgstreamer-plugins-bad1.0-0', 'gstreamer1.0-plugins-bad']
+      state: absent
+    become: yes


### PR DESCRIPTION
Hello @mirjan-hoffmann 

**gstreamer1.0-plugins-bad** and **libgstreamer-plugins-bad1.0-0** have for now some security issues, so I have removed it, for now, maybe we will see if it is fixed in the new versions, and we will remove this script again