### PR TITLE
add translted for custom license

### DIFF
--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -167,8 +167,12 @@ alfresco_ccmodel_add_custom_properties:
 #     - name: "Apache" # Required
 #       url: "https://opensource.org/licenses/Apache-2.0"  # Optional, since for now is not implemented in Edu-sharing
 #       position: 1    # Optional, if empty will be added in the end of dropdown
-#       description: "short  Description about the license, you can include the URL too"
-#       groups: "APACHE LICENSE" # Required
+#       description:   #short  Descriptions about the license, you can include the URL too
+#         - ["en","Description in English"]
+#         - ["de","Description in Deutsche "]
+#       groups:  # Required
+#       - ["en","APACHE LICENSE"]
+#       - ["de","APACHE LIZENZ"]
 #       image: "apache.svg"  # Required
 # 
 edu_custom_licenses:

--- a/ansible/roles/edu-sharing/tasks/custom-license.yml
+++ b/ansible/roles/edu-sharing/tasks/custom-license.yml
@@ -28,20 +28,37 @@
       when: custom_license is not none
       tags: edu-sharing-config        
 
-    # let's add/update the Key,value in ..common/[en/de].json files 
-    - name: set License name to ../common/[en-de].json
+    # let's add/update the Key,value for license NAME in ../common/[en/de].json files 
+    - name: set License NAME to ../common/[en-de].json
       # become: yes
       shell: | 
-        jq '.LICENSE.NAMES.{{custom_license.name|upper }} ="{{custom_license.name}}" |
-            .LICENSE.DESCRIPTION.{{custom_license.name|upper }} ="{{custom_license.description}}" | 
-            .LICENSE.GROUPS.{{custom_license.name|upper }} ="{{custom_license.groups}}"' {{ edu_home }}/war/edu_sharing/assets/i18n/common/{{item}} >tmp.json && mv tmp.json {{ edu_home }}/war/edu_sharing/assets/i18n/common/{{item}}
+        jq '.LICENSE.NAMES.{{custom_license.name|upper }} ="{{custom_license.name}}"' \
+        {{ edu_home }}/war/edu_sharing/assets/i18n/common/{{item}} >tmp.json && mv tmp.json {{ edu_home }}/war/edu_sharing/assets/i18n/common/{{item}}
       with_items:
         - de.json
         - en.json
       when: custom_license is not none
       tags: edu-sharing-config
 
-    #  add/update logo, for specific license
+      # let's add/update the Key,value for license DESCRIPTION in ../common/[en/de].json files 
+    - name: set License DESCRIPTION to ../common/[en-de].json
+      # become: yes
+      shell: | 
+        jq '.LICENSE.DESCRIPTION.{{custom_license.name|upper }} ="{{item[1]}}"' \ 
+        {{ edu_home }}/war/edu_sharing/assets/i18n/common/{{item[0]}}.json >tmp.json && mv tmp.json {{ edu_home }}/war/edu_sharing/assets/i18n/common/{{item[0]}}.json
+      loop: '{{ custom_license.description | default([], true) }}'
+      tags: edu-sharing-config        
+
+    # let's add/update the Key,value for license GROUPS in ../common/[en/de].json files 
+    - name: set License GROUP name to ../common/[en-de].json
+      # become: yes
+      shell: | 
+        jq '.LICENSE.GROUPS.{{custom_license.name|upper }} ="{{item[1]}}"' \
+        {{ edu_home }}/war/edu_sharing/assets/i18n/common/{{item[0]}}.json >tmp.json && mv tmp.json {{ edu_home }}/war/edu_sharing/assets/i18n/common/{{item[0]}}.json
+      loop: '{{ custom_license.groups | default([], true) }}'
+      tags: edu-sharing-config
+
+    # add/update logo, for specific license
     - name: set logo for custom license
       # become: yes
       copy:


### PR DESCRIPTION
Hello @mirjan-hoffmann 

Since other licenses are translated into other languages, then maybe is better to have the custom licenses shown in different languages.

What will be translated: 
  1- description
  2- Groups 
  
  
best regards
Edmond