### PR TITLE
Add classification keywords

### DIFF
--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -188,6 +188,10 @@ edu_custom_licenses:
 
 # activate the classification-keyword (true/false)
 activate_classification_keywords: false
+# activate the classification-keyword update (true/false)
+activate_classification_keywords_update: false
+# define the classification-keyword interval in days = 1 means every day
+classification_keywords_update_interval: 
 # give the path to the file where you want download the classification-keywords
 # must be public folder: example: /var/www/oer/ 
 classification_keywords_dir: 

--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -106,9 +106,14 @@ mirror_vocabularies: # list of vocabularies a local mirror should be created for
 #    target_directory: "/var/www/oer/vocabs-mirror"
 
 edu_migration_replace_mapping: # replace mapping jobs that should be executed during edu-sharing update (startFolder - root node, property - property that should be migrated, data - csv mapping)
-#  - startFolder: 869665e9-7e42-49af-bd30-6469e59904c5
-#    property: ccm:taxonid
-#    data: "{{ lookup('file', 'esconf/migration/mapping_taxonid.csv') }}"
+  #  - jobClass: "org.edu_sharing.repository.server.jobs.quartz.BulkEditNodesJob"
+  #    paramaeters:
+  #      - startFolder: "869665e9-7e42-49af-bd30-6469e59904c5"
+  #        property: "ccm:taxonid"
+  #        data: "{{ lookup('file', 'esconf/migration/mapping_taxonid.csv') }}"
+  #        recurseMode: "All"
+  #        mode: "ReplaceMapping"
+
 
 # define custom adjustments here to the ccContentModel.xml under tomcat/shared/classes/alfresco/extension/model/
 # use the mapping 'ns' for the namespace "http://www.alfresco.org/model/dictionary/1.0" in the xpath

--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -106,13 +106,9 @@ mirror_vocabularies: # list of vocabularies a local mirror should be created for
 #    target_directory: "/var/www/oer/vocabs-mirror"
 
 edu_migration_replace_mapping: # replace mapping jobs that should be executed during edu-sharing update (startFolder - root node, property - property that should be migrated, data - csv mapping)
-  #  - jobClass: "org.edu_sharing.repository.server.jobs.quartz.BulkEditNodesJob"
-  #    paramaeters:
-  #      - startFolder: "869665e9-7e42-49af-bd30-6469e59904c5"
-  #        property: "ccm:taxonid"
-  #        data: "{{ lookup('file', 'esconf/migration/mapping_taxonid.csv') }}"
-  #        recurseMode: "All"
-  #        mode: "ReplaceMapping"
+#  - startFolder: 869665e9-7e42-49af-bd30-6469e59904c5
+#    property: ccm:taxonid
+#    data: "{{ lookup('file', 'esconf/migration/mapping_taxonid.csv') }}"
 
 
 # define custom adjustments here to the ccContentModel.xml under tomcat/shared/classes/alfresco/extension/model/
@@ -184,26 +180,15 @@ edu_custom_licenses:
 
 
 # define config for classifications keywords
-# After activated the classification-keywords, you need to add an edu-sharing job in "edu_migration_replace_mapping" variable
-# example: 
-# edu_migration_replace_mapping:
-    # - jobClass: "org.edu_sharing.repository.server.jobs.quartz.ImportFactualTermMarc21"
-    #  parameters:
-    #    - fileUri: '{{ edu_sharing_protocol | default("http") }}://{{edu_sharing_host}}/oer/{{classification_keywords_file}}'
-
+# they are also some default configurations in /roles/edu-sharing/default/main/yml
 # activate the classification-keyword (true/false)
 activate_classification_keywords: false
 # activate the classification-keyword update (true/false)
 activate_classification_keywords_update: false
-# define the classification-keyword interval in days = 1 means every day
-classification_keywords_update_interval: 
-# give the path to the file where you want download the classification-keywords
-# must be public folder: example: /var/www/oer/ 
+# must be public folder: example: /oer/classification-keywords
 classification_keywords_dir: 
 # define the classification-keyword file name example: classification_keywords.xml
 classification_keywords_file: 
-# Classification-Keywords-URL (for download)
-classification_keywords_url: "https://data.dnb.de/GND/authorities-sachbegriff_dnbmarc_20211013.mrc.xml.gz"
 # Override the default local file 
 classification_keywords_force_download: false
 

--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -110,7 +110,6 @@ edu_migration_replace_mapping: # replace mapping jobs that should be executed du
 #    property: ccm:taxonid
 #    data: "{{ lookup('file', 'esconf/migration/mapping_taxonid.csv') }}"
 
-
 # define custom adjustments here to the ccContentModel.xml under tomcat/shared/classes/alfresco/extension/model/
 # use the mapping 'ns' for the namespace "http://www.alfresco.org/model/dictionary/1.0" in the xpath
 # format:

--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -180,17 +180,16 @@ edu_custom_licenses:
 
 
 # define config for classifications keywords
-# they are also some default configurations in /roles/edu-sharing/default/main/yml
 # activate the classification-keyword (true/false)
-activate_classification_keywords: false
+activate_classification_keywords: true
 # activate the classification-keyword update (true/false)
 activate_classification_keywords_update: false
-# must be public folder: example: /oer/classification-keywords
-classification_keywords_dir: 
-# define the classification-keyword file name example: classification_keywords.xml
-classification_keywords_file: 
 # Override the default local file 
 classification_keywords_force_download: false
+# define the classification-keyword interval in days = 1 means every day
+classification_keywords_update_interval: 15
+# Classification-Keywords-URL (for download)
+classification_keywords_url: "https://data.dnb.de/GND/authorities-sachbegriff_dnbmarc_20211013.mrc.xml.gz"
 
 
 edu_connected_lms: # list of LMS configurations. Connect these LMS with edu-sharing (appid - id of the LMS, public_key - public key of the LMS (from the xml-file), host - public IP of the LMS)

--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -176,3 +176,24 @@ alfresco_ccmodel_add_custom_properties:
 #       image: "apache.svg"  # Required
 # 
 edu_custom_licenses:
+
+
+# define config for classifications keywords
+# After activated the classification-keywords, you need to add an edu-sharing job in "edu_migration_replace_mapping" variable
+# example: 
+# edu_migration_replace_mapping:
+    # - jobClass: "org.edu_sharing.repository.server.jobs.quartz.ImportFactualTermMarc21"
+    #  parameters:
+    #    - fileUri: '{{ edu_sharing_protocol | default("http") }}://{{edu_sharing_host}}/oer/{{classification_keywords_file}}'
+
+# activate the classification-keyword (true/false)
+activate_classification_keywords: false
+# give the path to the file where you want download the classification-keywords
+# must be public folder: example: /var/www/oer/ 
+classification_keywords_dir: 
+# define the classification-keyword file name example: classification_keywords.xml
+classification_keywords_file: 
+# Classification-Keywords-URL (for download)
+classification_keywords_url: "https://data.dnb.de/GND/authorities-sachbegriff_dnbmarc_20211013.mrc.xml.gz"
+# Override the default local file 
+classification_keywords_force_download: false

--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -181,7 +181,7 @@ edu_custom_licenses:
 
 # define config for classifications keywords
 # activate the classification-keyword (true/false)
-activate_classification_keywords: true
+activate_classification_keywords: false
 # activate the classification-keyword update (true/false)
 activate_classification_keywords_update: false
 # Override the default local file 

--- a/ansible/roles/apache/templates/apache_vhost.conf.j2
+++ b/ansible/roles/apache/templates/apache_vhost.conf.j2
@@ -24,6 +24,16 @@
         ProxyPass /edu-sharing  ajp://localhost:{{tomcat_ajp_port}}/edu-sharing
 {% endif %}
 
+{% if activate_classification_keywords is defined and activate_classification_keywords %}
+        DocumentRoot /var/www
+        
+        <Directory classification-keywords/ >
+          Options Indexes FollowSymLinks MultiViews
+          AllowOverride All
+          Require all granted
+        </Directory>
+{% endif %}
+
         ErrorLog ${APACHE_LOG_DIR}/error.log
         CustomLog ${APACHE_LOG_DIR}/access.log combined
 </VirtualHost>

--- a/ansible/roles/edu-sharing/defaults/main.yml
+++ b/ansible/roles/edu-sharing/defaults/main.yml
@@ -54,3 +54,21 @@ oersi_port: "443"
 oersi_scheme: "https"
 oersi_pathprefix: "/resources/api-internal/search"
 oersi_index: "oer_data"
+
+# Default values for classifications keywords
+# define the classification-keyword interval in days = 1 means every day
+classification_keywords_update_interval: 15
+# give the path to the file where you want download the classification-keywords
+# must be public folder: example: /var/www/oer/
+classification_keywords_dir: "classification-keywords"
+#  classification keywords base dir
+classification_keywords_base_dir: "/var/www/html/{{classification_keywords_dir}}"
+# define the classification-keyword file name example: classification_keywords.xml
+classification_keywords_file: "classification_keywords.xml"
+# Classification-Keywords-URL (for download)
+classification_keywords_url: "https://data.dnb.de/GND/authorities-sachbegriff_dnbmarc_20211013.mrc.xml.gz"
+# classification-keywords initial by job
+classification_keywords_job:
+    jobClass: "org.edu_sharing.repository.server.jobs.quartz.ImportFactualTermMarc21"
+    params:
+       fileUri: '{{ edu_sharing_protocol | default("http") }}://{{edu_sharing_host}}/{{classification_keywords_dir}}/{{classification_keywords_file}}'

--- a/ansible/roles/edu-sharing/defaults/main.yml
+++ b/ansible/roles/edu-sharing/defaults/main.yml
@@ -62,7 +62,7 @@ classification_keywords_update_interval: 15
 # must be public folder: example: /var/www/oer/
 classification_keywords_dir: "classification-keywords"
 #  classification keywords base dir
-classification_keywords_base_dir: "/var/www/html/{{classification_keywords_dir}}"
+classification_keywords_base_dir: "/var/www/{{classification_keywords_dir}}"
 # define the classification-keyword file name example: classification_keywords.xml
 classification_keywords_file: "classification_keywords.xml"
 # Classification-Keywords-URL (for download)

--- a/ansible/roles/edu-sharing/defaults/main.yml
+++ b/ansible/roles/edu-sharing/defaults/main.yml
@@ -54,21 +54,3 @@ oersi_port: "443"
 oersi_scheme: "https"
 oersi_pathprefix: "/resources/api-internal/search"
 oersi_index: "oer_data"
-
-# Default values for classifications keywords
-# define the classification-keyword interval in days = 1 means every day
-classification_keywords_update_interval: 15
-# give the path to the file where you want download the classification-keywords
-# must be public folder: example: /var/www/oer/
-classification_keywords_dir: "classification-keywords"
-#  classification keywords base dir
-classification_keywords_base_dir: "/var/www/{{classification_keywords_dir}}"
-# define the classification-keyword file name example: classification_keywords.xml
-classification_keywords_file: "classification_keywords.xml"
-# Classification-Keywords-URL (for download)
-classification_keywords_url: "https://data.dnb.de/GND/authorities-sachbegriff_dnbmarc_20211013.mrc.xml.gz"
-# classification-keywords initial by job
-classification_keywords_job:
-    jobClass: "org.edu_sharing.repository.server.jobs.quartz.ImportFactualTermMarc21"
-    params:
-       fileUri: '{{ edu_sharing_protocol | default("http") }}://{{edu_sharing_host}}/{{classification_keywords_dir}}/{{classification_keywords_file}}'

--- a/ansible/roles/edu-sharing/tasks/classification-keyword.yml
+++ b/ansible/roles/edu-sharing/tasks/classification-keyword.yml
@@ -1,0 +1,69 @@
+---
+
+- name: Ensure gzip is present
+  package:
+    name: ["gzip"]
+  become: yes
+  tags:
+  - packages
+  - root-task
+
+
+- name : delete old classification_keywords.xml
+  file:
+    path: "{{classification_keywords_dir}}/{{classification_keywords_file}}"
+    state: absent
+  when: classification_keywords_force_download
+  tags:
+  - classification-keyword
+
+- name: Ensure classification_keywords_dir dir exists
+  file: 
+    path: "{{ classification_keywords_dir }}" 
+    state: directory
+    group: "www-data"
+    owner: "www-data"
+  tags:
+  - classification-keyword
+
+- name: check if classification_keywords xml file exist
+  stat: path="{{classification_keywords_dir}}/{{classification_keywords_file}}"
+  register: classification_keywords_xml_file_exist
+  tags: 
+  - classification-keyword
+
+- name: download classification keywords gz format
+  get_url:
+    url: '{{classification_keywords_url}}'
+    dest: "{{classification_keywords_dir}}/{{classification_keywords_file}}.gz"
+    group: "www-data"
+    owner: "www-data"
+    force: yes
+  when: not classification_keywords_xml_file_exist.stat.exists
+  tags:
+  - classification-keyword
+
+
+
+
+- name: unzip classification keywords gz format
+  command:
+    chdir: '{{classification_keywords_dir}}/'
+    cmd: 'gunzip {{classification_keywords_file}}.gz'
+    creates: '{{classification_keywords_dir}}/{{classification_keywords_file}}'
+  when: not classification_keywords_xml_file_exist.stat.exists
+  tags:
+  - classification-keyword
+
+- name: remove gz file
+  file: path="{{classification_keywords_dir}}/{{classification_keywords_file}}.gz" state=absent
+  tags:
+  - classification-keyword
+
+
+
+
+
+
+
+

--- a/ansible/roles/edu-sharing/tasks/classification-keyword.yml
+++ b/ansible/roles/edu-sharing/tasks/classification-keyword.yml
@@ -11,15 +11,15 @@
 
 - name : delete old classification_keywords.xml
   file:
-    path: "{{classification_keywords_dir}}/{{classification_keywords_file}}"
+    path: "{{classification_keywords_base_dir}}/{{classification_keywords_file}}"
     state: absent
   when: classification_keywords_force_download
   tags:
   - classification-keyword
 
-- name: Ensure classification_keywords_dir dir exists
+- name: Ensure classification_keywords_base_dir dir exists
   file: 
-    path: "{{ classification_keywords_dir }}" 
+    path: "{{ classification_keywords_base_dir }}" 
     state: directory
     group: "www-data"
     owner: "www-data"
@@ -27,7 +27,7 @@
   - classification-keyword
 
 - name: check if classification_keywords xml file exist
-  stat: path="{{classification_keywords_dir}}/{{classification_keywords_file}}"
+  stat: path="{{classification_keywords_base_dir}}/{{classification_keywords_file}}"
   register: classification_keywords_xml_file_exist
   tags: 
   - classification-keyword
@@ -35,7 +35,7 @@
 - name: download classification keywords gz format
   get_url:
     url: '{{classification_keywords_url}}'
-    dest: "{{classification_keywords_dir}}/{{classification_keywords_file}}.gz"
+    dest: "{{classification_keywords_base_dir}}/{{classification_keywords_file}}.gz"
     group: "www-data"
     owner: "www-data"
     force: yes
@@ -43,27 +43,23 @@
   tags:
   - classification-keyword
 
-
-
-
 - name: unzip classification keywords gz format
   command:
-    chdir: '{{classification_keywords_dir}}/'
+    chdir: '{{classification_keywords_base_dir}}/'
     cmd: 'gunzip {{classification_keywords_file}}.gz'
-    creates: '{{classification_keywords_dir}}/{{classification_keywords_file}}'
+    creates: '{{classification_keywords_base_dir}}/{{classification_keywords_file}}'
   when: not classification_keywords_xml_file_exist.stat.exists
   tags:
   - classification-keyword
 
 - name: remove gz file
-  file: path="{{classification_keywords_dir}}/{{classification_keywords_file}}.gz" state=absent
+  file: path="{{classification_keywords_base_dir}}/{{classification_keywords_file}}.gz" state=absent
   tags:
   - classification-keyword
 
-
-
-
-
-
-
-
+- name: Add job for classification keywords
+  set_fact:
+    edu_jobs_all: "{{ edu_jobs_all | default([], true) + [{'jobClass': classification_keywords_job.jobClass, 'params': { 'fileUri':classification_keywords_job.params.fileUri} }] }}"
+  when: classification_keywords_job.jobClass is defined and classification_keywords_job.params is defined
+  tags:
+  - classification-keyword

--- a/ansible/roles/edu-sharing/tasks/classification-keyword.yml
+++ b/ansible/roles/edu-sharing/tasks/classification-keyword.yml
@@ -63,7 +63,3 @@
          {{ edu_jobs_all | default([], true) + [{'jobClass': 'org.edu_sharing.repository.server.jobs.quartz.ImportFactualTermMarc21', 'params': { 'fileUri': '{{ edu_sharing_protocol | default("http") }}://{{edu_sharing_host}}/classification-keywords/classification_keywords.xml' } }] }}
   tags:
   - classification-keyword
-
-- name: debug edu_jobs_all
-  debug:
-    var: edu_jobs_all

--- a/ansible/roles/edu-sharing/tasks/classification-keyword.yml
+++ b/ansible/roles/edu-sharing/tasks/classification-keyword.yml
@@ -11,15 +11,15 @@
 
 - name : delete old classification_keywords.xml
   file:
-    path: "{{classification_keywords_base_dir}}/{{classification_keywords_file}}"
+    path: "/var/www/classification-keywords/classification_keywords.xml"
     state: absent
   when: classification_keywords_force_download
   tags:
   - classification-keyword
 
-- name: Ensure classification_keywords_base_dir dir exists
+- name: Ensure classification keywords dir exists
   file: 
-    path: "{{ classification_keywords_base_dir }}" 
+    path: "/var/www/classification-keywords" 
     state: directory
     group: "www-data"
     owner: "www-data"
@@ -27,7 +27,7 @@
   - classification-keyword
 
 - name: check if classification_keywords xml file exist
-  stat: path="{{classification_keywords_base_dir}}/{{classification_keywords_file}}"
+  stat: path="/var/www/classification-keywords/classification_keywords.xml"
   register: classification_keywords_xml_file_exist
   tags: 
   - classification-keyword
@@ -35,7 +35,7 @@
 - name: download classification keywords gz format
   get_url:
     url: '{{classification_keywords_url}}'
-    dest: "{{classification_keywords_base_dir}}/{{classification_keywords_file}}.gz"
+    dest: "/var/www/classification-keywords/classification_keywords.xml.gz"
     group: "www-data"
     owner: "www-data"
     force: yes
@@ -45,21 +45,25 @@
 
 - name: unzip classification keywords gz format
   command:
-    chdir: '{{classification_keywords_base_dir}}/'
-    cmd: 'gunzip {{classification_keywords_file}}.gz'
-    creates: '{{classification_keywords_base_dir}}/{{classification_keywords_file}}'
+    chdir: '/var/www/classification-keywords/'
+    cmd: 'gunzip classification_keywords.xml.gz'
+    creates: '/var/www/classification-keywords/classification_keywords.xml'
   when: not classification_keywords_xml_file_exist.stat.exists
   tags:
   - classification-keyword
 
 - name: remove gz file
-  file: path="{{classification_keywords_base_dir}}/{{classification_keywords_file}}.gz" state=absent
+  file: path="/var/www/classification-keywords/classification_keywords.xml.gz" state=absent
   tags:
   - classification-keyword
 
 - name: Add job for classification keywords
   set_fact:
-    edu_jobs_all: "{{ edu_jobs_all | default([], true) + [{'jobClass': classification_keywords_job.jobClass, 'params': { 'fileUri':classification_keywords_job.params.fileUri} }] }}"
-  when: classification_keywords_job.jobClass is defined and classification_keywords_job.params is defined
+    edu_jobs_all: > 
+         {{ edu_jobs_all | default([], true) + [{'jobClass': 'org.edu_sharing.repository.server.jobs.quartz.ImportFactualTermMarc21', 'params': { 'fileUri': '{{ edu_sharing_protocol | default("http") }}://{{edu_sharing_host}}/classification-keywords/classification_keywords.xml' } }] }}
   tags:
   - classification-keyword
+
+- name: debug edu_jobs_all
+  debug:
+    var: edu_jobs_all

--- a/ansible/roles/edu-sharing/tasks/jobs.yml
+++ b/ansible/roles/edu-sharing/tasks/jobs.yml
@@ -1,8 +1,10 @@
 ---
 - name: add replace-mapping-jobs to list of all jobs
   set_fact:
-    edu_jobs_all: "{{ edu_jobs_all | default([], true) + [{'jobClass': 'org.edu_sharing.repository.server.jobs.quartz.BulkEditNodesJob', 'params': {'startFolder': item.startFolder, 'mode': 'ReplaceMapping', 'property': item.property, 'types': 'ccm:io', 'recurseMode': 'All', 'FILE_DATA': item.data}}, {'jobClass': 'org.edu_sharing.repository.server.jobs.quartz.BulkEditNodesJob', 'params': {'startFolder': item.startFolder, 'mode': 'RemoveDuplicates', 'property': item.property, 'types': 'ccm:io', 'recurseMode': 'All'}}] }}"
-  loop: '{{ edu_migration_replace_mapping | default([], true) }}'
+    edu_jobs_all: "{{ edu_jobs_all | default([], true) + [{'jobClass': item.0.jobClass, 'params': item.1 }] }}"
+  with_subelements:
+    - '{{ edu_migration_replace_mapping | default([], true) }}'
+    - parameters
 
 - name: "wait for tomcat to come up"
   uri:

--- a/ansible/roles/edu-sharing/tasks/jobs.yml
+++ b/ansible/roles/edu-sharing/tasks/jobs.yml
@@ -1,10 +1,8 @@
 ---
 - name: add replace-mapping-jobs to list of all jobs
   set_fact:
-    edu_jobs_all: "{{ edu_jobs_all | default([], true) + [{'jobClass': item.0.jobClass, 'params': item.1 }] }}"
-  with_subelements:
-    - '{{ edu_migration_replace_mapping | default([], true) }}'
-    - parameters
+    edu_jobs_all: "{{ edu_jobs_all | default([], true) + [{'jobClass': 'org.edu_sharing.repository.server.jobs.quartz.BulkEditNodesJob', 'params': {'startFolder': item.startFolder, 'mode': 'ReplaceMapping', 'property': item.property, 'types': 'ccm:io', 'recurseMode': 'All', 'FILE_DATA': item.data}}, {'jobClass': 'org.edu_sharing.repository.server.jobs.quartz.BulkEditNodesJob', 'params': {'startFolder': item.startFolder, 'mode': 'RemoveDuplicates', 'property': item.property, 'types': 'ccm:io', 'recurseMode': 'All'}}] }}"
+  loop: '{{ edu_migration_replace_mapping | default([], true) }}'
 
 - name: "wait for tomcat to come up"
   uri:

--- a/ansible/roles/edu-sharing/tasks/main.yml
+++ b/ansible/roles/edu-sharing/tasks/main.yml
@@ -20,7 +20,7 @@
   - include: users.yml
   - include: classification-keyword.yml
     become: true
-    when: activate_classifications_keywords is defined and activate_classifications_keywords
+    when: activate_classification_keywords is defined and activate_classification_keywords
   - include: jobs.yml
   - include: pixabay.yml
     when: connect_content_pixabay

--- a/ansible/roles/edu-sharing/tasks/main.yml
+++ b/ansible/roles/edu-sharing/tasks/main.yml
@@ -18,6 +18,9 @@
       - antivirus
   - include: edusharing.yml
   - include: users.yml
+  - include: classification-keyword.yml
+    become: true
+    when: activate_classifications_keywords is defined and activate_classifications_keywords
   - include: jobs.yml
   - include: pixabay.yml
     when: connect_content_pixabay

--- a/ansible/roles/edu-sharing/templates/edu-sharing.conf.j2
+++ b/ansible/roles/edu-sharing/templates/edu-sharing.conf.j2
@@ -15,3 +15,21 @@ repository: {
     }
 {% endif %}
 }
+
+{% if activate_classification_keywords is defined and activate_classification_keywords and activate_classification_keywords_update is defined and activate_classification_keywords_update %}
+jobs.entries += {
+    name: "Import Factual Term Marc 21",
+    class: "org.edu_sharing.repository.server.jobs.quartz.ImporterJob",
+    trigger: "Cron[0 0 22 * * ?]",
+    params: {
+        "oai_base_url": "[https://services.dnb.de/oai/repository]",
+        "oai_metadata_prefix": "MARC21-xml",
+        "sets": "authorities:sachbegriff",
+        "record_handler": "org.edu_sharing.repository.server.importer.RecordHandlerKeywordsDNBMarc",
+        "persistent_handler": "org.edu_sharing.repository.server.importer.PersistenHandlerKeywordsDNBMarc",
+        "importer_class": "org.edu_sharing.repository.server.importer.OAIPMHLOMImporter",
+        "period_in_days": {{ classification_keywords_update_interval | default("10",true)}},
+        "username": "admin"
+    }
+}
+{% endif %}


### PR DESCRIPTION
Hello @mirjan-hoffmann 

I added the implementation for classification keywords:

What include this pull request:

  1. Implemented classification keywords, possibility to activate/deactivate
  2. Implement job to auto-update classifications keywords in edu-sharing.conf 
  3. I have refactored a little bit your implementation for jobs, [`edu_migration_replace_mapping`](https://github.com/Edmondi-Kacaj/edu-sharing-box/blob/a49dedb891e249649d5f611fadf4bfff3dffae93/ansible/group_vars/edusharing.yml) See also [jobs.yml](https://github.com/Edmondi-Kacaj/edu-sharing-box/blob/a49dedb891e249649d5f611fadf4bfff3dffae93/ansible/roles/edu-sharing/tasks/jobs.yml#L3-L7), I saw and for now, we haven't used yet this implementation, I think is not problem that I refactored, I think is better to have this more generic and use for each need we will have.
  

