### PR TITLE
Fix classification keywords

### DIFF
--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -189,8 +189,8 @@ classification_keywords_force_download: false
 classification_keywords_update_interval: 15
 # Classification-Keywords-URL (for download)
 classification_keywords_url: "https://data.dnb.de/GND/authorities-sachbegriff_dnbmarc_20211013.mrc.xml.gz"
-# classification keyword default file is located in ansible/roles/edu-sharing/defaults/main.yml you can change it here
-# example:  edu_classification_keyword_path: "classification-keywords/classification-keywords.xml"
+# classification keyword default file 
+edu_classification_keyword_path: "classification-keywords/classification-keywords.xml"
 
 
 edu_connected_lms: # list of LMS configurations. Connect these LMS with edu-sharing (appid - id of the LMS, public_key - public key of the LMS (from the xml-file), host - public IP of the LMS)

--- a/ansible/group_vars/edusharing.yml
+++ b/ansible/group_vars/edusharing.yml
@@ -189,6 +189,8 @@ classification_keywords_force_download: false
 classification_keywords_update_interval: 15
 # Classification-Keywords-URL (for download)
 classification_keywords_url: "https://data.dnb.de/GND/authorities-sachbegriff_dnbmarc_20211013.mrc.xml.gz"
+# classification keyword default file is located in ansible/roles/edu-sharing/defaults/main.yml you can change it here
+# example:  edu_classification_keyword_path: "classification-keywords/classification-keywords.xml"
 
 
 edu_connected_lms: # list of LMS configurations. Connect these LMS with edu-sharing (appid - id of the LMS, public_key - public key of the LMS (from the xml-file), host - public IP of the LMS)

--- a/ansible/roles/apache/templates/apache_vhost.conf.j2
+++ b/ansible/roles/apache/templates/apache_vhost.conf.j2
@@ -26,8 +26,7 @@
 
 {% if activate_classification_keywords is defined and activate_classification_keywords %}
         DocumentRoot /var/www
-        
-        <Directory classification-keywords/ >
+        <Directory /var/www/{{edu_classification_keyword_path | dirname }} >
           Options Indexes FollowSymLinks MultiViews
           AllowOverride All
           Require all granted

--- a/ansible/roles/edu-sharing/defaults/main.yml
+++ b/ansible/roles/edu-sharing/defaults/main.yml
@@ -54,6 +54,3 @@ oersi_port: "443"
 oersi_scheme: "https"
 oersi_pathprefix: "/resources/api-internal/search"
 oersi_index: "oer_data"
-
-# classification keyword default file
-edu_classification_keyword_path: "classification-keywords/classification-keywords.xml"

--- a/ansible/roles/edu-sharing/defaults/main.yml
+++ b/ansible/roles/edu-sharing/defaults/main.yml
@@ -54,3 +54,6 @@ oersi_port: "443"
 oersi_scheme: "https"
 oersi_pathprefix: "/resources/api-internal/search"
 oersi_index: "oer_data"
+
+# classification keyword default file
+edu_classification_keyword_path: "classification-keywords/classification-keywords.xml"

--- a/ansible/roles/edu-sharing/tasks/classification-keyword.yml
+++ b/ansible/roles/edu-sharing/tasks/classification-keyword.yml
@@ -11,7 +11,7 @@
 
 - name : delete old classification_keywords.xml
   file:
-    path: "/var/www/classification-keywords/classification_keywords.xml"
+    path: "/var/www/{{edu_classification_keyword_default_path}}"
     state: absent
   when: classification_keywords_force_download
   tags:
@@ -19,7 +19,7 @@
 
 - name: Ensure classification keywords dir exists
   file: 
-    path: "/var/www/classification-keywords" 
+    path: '/var/www/{{edu_classification_keyword_path | dirname}}'
     state: directory
     group: "www-data"
     owner: "www-data"
@@ -27,7 +27,7 @@
   - classification-keyword
 
 - name: check if classification_keywords xml file exist
-  stat: path="/var/www/classification-keywords/classification_keywords.xml"
+  stat: path="/var/www/{{edu_classification_keyword_path}}"
   register: classification_keywords_xml_file_exist
   tags: 
   - classification-keyword
@@ -35,7 +35,7 @@
 - name: download classification keywords gz format
   get_url:
     url: '{{classification_keywords_url}}'
-    dest: "/var/www/classification-keywords/classification_keywords.xml.gz"
+    dest: "/var/www/{{edu_classification_keyword_path}}.gz"
     group: "www-data"
     owner: "www-data"
     force: yes
@@ -45,21 +45,21 @@
 
 - name: unzip classification keywords gz format
   command:
-    chdir: '/var/www/classification-keywords/'
-    cmd: 'gunzip classification_keywords.xml.gz'
-    creates: '/var/www/classification-keywords/classification_keywords.xml'
+    chdir: '/var/www/{{edu_classification_keyword_path | dirname  }}'
+    cmd: 'gunzip {{edu_classification_keyword_path | basename }}.gz'
+    creates: '/var/www/{{edu_classification_keyword_path}}'
   when: not classification_keywords_xml_file_exist.stat.exists
   tags:
   - classification-keyword
 
 - name: remove gz file
-  file: path="/var/www/classification-keywords/classification_keywords.xml.gz" state=absent
+  file: path="/var/www/{{edu_classification_keyword_path | basename }}.gz" state=absent
   tags:
   - classification-keyword
 
 - name: Add job for classification keywords
   set_fact:
     edu_jobs_all: > 
-         {{ edu_jobs_all | default([], true) + [{'jobClass': 'org.edu_sharing.repository.server.jobs.quartz.ImportFactualTermMarc21', 'params': { 'fileUri': '{{ edu_sharing_protocol | default("http") }}://{{edu_sharing_host}}/classification-keywords/classification_keywords.xml' } }] }}
+         {{ edu_jobs_all | default([], true) + [{'jobClass': 'org.edu_sharing.repository.server.jobs.quartz.ImportFactualTermMarc21', 'params': { 'fileUri': '{{ edu_sharing_protocol | default("http") }}://{{edu_sharing_host}}/{{edu_classification_keyword_path}}' } }] }}
   tags:
   - classification-keyword

--- a/ansible/roles/edu-sharing/tasks/classification-keyword.yml
+++ b/ansible/roles/edu-sharing/tasks/classification-keyword.yml
@@ -11,7 +11,7 @@
 
 - name : delete old classification_keywords.xml
   file:
-    path: "/var/www/{{edu_classification_keyword_default_path}}"
+    path: "/var/www/{{edu_classification_keyword_path}}"
     state: absent
   when: classification_keywords_force_download
   tags:

--- a/ansible/roles/edu-sharing/tasks/classification-keyword.yml
+++ b/ansible/roles/edu-sharing/tasks/classification-keyword.yml
@@ -53,7 +53,7 @@
   - classification-keyword
 
 - name: remove gz file
-  file: path="/var/www/{{edu_classification_keyword_path | basename }}.gz" state=absent
+  file: path="/var/www/{{edu_classification_keyword_path}}.gz" state=absent
   tags:
   - classification-keyword
 


### PR DESCRIPTION
Hello @mirjan-hoffmann 

Since we had a little problem in implementing **classification keywords** feature in our systems, then I have adjusted a little bit.

changes include: 
   1. I have added a variable in default variables: **_edu_classification_keyword_path_** with default values so only if we need to override it then we can override otherwise we can leave it as is it, I thought it better if we include it in default rather then in general configuration since mostly it will not be changed by users, (only when is need it, our example).
   
   2. I have added a comment next to other variables for activating classification keywords that if someone wants to changes it can find it.
   
   
I hope this adjust it will be OK for you.