### PR TITLE
add tags for custom menu entries

### DIFF
--- a/ansible/roles/edu-sharing/tasks/edusharing.yml
+++ b/ansible/roles/edu-sharing/tasks/edusharing.yml
@@ -123,6 +123,7 @@
   with_items: '{{ edu_custom_menu_entries | default([], true) }}'
   loop_control:
     loop_var: custom_menu_entry
+  tags: edu-sharing-config
 
 # -------- Menu entries (END)-------- #
 


### PR DESCRIPTION
Hello @mirjan-hoffmann 

If we run ansible by tags for updating the edu-sharing box, then the custom entries will be deleted.

I have added the tag `edu-sharing-config`, to update also the custom entries task.