### PR TITLE
fix render-service extract source, since they made some changes

### DIFF
--- a/ansible/roles/renderingservice-installation/tasks/esrender.yml
+++ b/ansible/roles/renderingservice-installation/tasks/esrender.yml
@@ -49,7 +49,7 @@
     dest: '{{esrender_document_root}}'
     extra_opts:
       - --transform
-      - s/^renderingservice-[0-9.a-zA-Z-]*/esrender/
+      - s/^edu-sharing-community-services-rendering-[0-9.a-zA-Z-]*/esrender/
   notify:
     - restart apache2
 


### PR DESCRIPTION
Hello @mirjan-hoffmann 

Metaventis made some changes in the render service and now the extracted source does not work as we expected, so I fixed this problem.

- s/^renderingservice-[0-9.a-zA-Z-]*/esrender/
+ s/^edu-sharing-community-services-rendering-[0-9.a-zA-Z-]*/esrender/