### PR TITLE
fix(edu-sharing) add remote_src: yes , to copy files form target host

### DIFF
--- a/ansible/roles/edu-sharing/tasks/edu-sharing-docker/migrate-alfresco-data.yml
+++ b/ansible/roles/edu-sharing/tasks/edu-sharing-docker/migrate-alfresco-data.yml
@@ -68,6 +68,7 @@
     mode: "{{alfresco_volume_data_stats.stat.mode}}"
     owner: "{{alfresco_volume_data_stats.stat.uid}}"
     group: "{{alfresco_volume_data_stats.stat.gid}}"
+    remote_src: yes
   when: (alfresco_volume_data.stdout is defined and alfresco_volume_data.stdout != "") and 
         (alfresco_volume_data_stats.stat.isdir is defined and alfresco_volume_data_stats.stat.isdir)
   tags:


### PR DESCRIPTION
Hello @mirjan-hoffmann 

We had a problem when we copy data from the same location, looks like Ansible by default tries to copy data from the host where the playbook is being executed, rather than the  target host

see: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html#parameter-remote_src


this pull request fixes this problem.