### PR TITLE
fix(edu-sharing) run docker with  sg, #40

### DIFF
--- a/ansible/roles/edu-sharing/tasks/edu-sharing-docker/edu-sharing-config-file.yml
+++ b/ansible/roles/edu-sharing/tasks/edu-sharing-docker/edu-sharing-config-file.yml
@@ -1,7 +1,7 @@
 ---
 - name: Get the path to the edu-sharing cluster docker volume.
   shell: |
-    sg docker -c "docker volume inspect --format '{{ '{{' }}.Mountpoint{{ '}}' }}'  $(docker volume ls -q |grep '_repository-service-volume-config-cluster')"
+    sg docker -c "docker volume inspect --format '{{ '{{' }}.Mountpoint{{ '}}' }}'  $(sg docker -c "docker volume ls -q |grep '_repository-service-volume-config-cluster'")"
   register: repository_volume_config_cluster
   ignore_errors: true
   tags:


### PR DESCRIPTION
Hello @mirjan-hoffmann 

according to issue #40, the docker-group is not available in machine for the first time, we already discussed this, that ansible does not update the session, and for that, if the docker was installed for the first time in the machine it will through an error, I created a pull request to fix this problem, by running docker wi sg docker, example `sg docker -c "docker version"`