### PR TITLE
fix(edu-sharing) give more time for getting acces token from edu-sharing docker version

### DIFF
--- a/ansible/roles/edu-sharing/tasks/common/jobs.yml
+++ b/ansible/roles/edu-sharing/tasks/common/jobs.yml
@@ -29,6 +29,9 @@
     body: 'grant_type=password&client_id=eduApp&client_secret=secret&username=admin&password={{ alf_password }}'
     return_content: yes
   register: accesstokenreply
+  until: accesstokenreply.status == 200
+  retries: 5
+  delay: 10
   no_log: true
   when: edu_jobs_all | default([], true) | length>0
 


### PR DESCRIPTION
Hello @mirjan-hoffmann 

Since sometimes the getting access token gives us an unresponsive error since it will take more time, I created a pull request that waits a little bit, for a response from edu-sharing