### PR TITLE
remove warning message for edu-sharing >= 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # edu-sharing-box
 
-```diff
--  Warning!! Do not use Edu-sharing version 7 for production, we are still working on it
-```
-
 
 Dieses Projekt bietet die Möglichkeit, ein edu-sharing mit minimalem Aufwand in einer virtuellen Maschine aufzusetzen. Voraussetzung ist die Installation von
 [Git](https://git-scm.com/downloads),  [Vagrant](https://www.vagrantup.com/downloads.html) und [VirtualBox](https://www.virtualbox.org/wiki/Downloads).


### PR DESCRIPTION
Hello @mirjan-hoffmann 

since we are now working and using ES-v8 and it also worked with 7 in the test server, I think we can remove the Warning message from the ReadMe.md file, 

What is Removed:
```diff
-  Warning!! Do not use Edu-sharing version 7 for production, we are still working on it
```
