### PR TITLE
fix(edu-sharing-docker) Remove only the edu-sharing volumes

### DIFF
--- a/ansible/roles/edu-sharing/tasks/edu-sharing-docker/clean-edu-sharing-volumes.yml
+++ b/ansible/roles/edu-sharing/tasks/edu-sharing-docker/clean-edu-sharing-volumes.yml
@@ -24,7 +24,7 @@
 
 - name: Get a list of all volumes.
   shell: >
-    sg docker -c "docker volume ls --quiet || true"
+    sg docker -c "docker volume ls --quiet --quiet --filter name='^{{edu_sharing_docker_project_name}}' || true"
   register: volumes_list
   changed_when: volumes_list.stdout != ""
 


### PR DESCRIPTION
Hello @mirjan-hoffmann,

The updated script ensures that only volumes associated with the edu-sharing application are deleted, while ignoring volumes from other Docker apps.

Previously, the script attempted to delete all volumes, causing errors when some volumes were still in use by other active Docker apps. With this pull request, the script now removes only the volumes related to the edu-sharing application.

Specifically, when updating the edu-sharing version (e.g., from 8.0.0 to 8.1.0), the script will delete all containers, volumes, and images from the previous edu-sharing version, except for the 'repository-database-volume-data' and 'repository-service-volume-data' volumes, which contain important data such as the database and alf_data.

