### PR TITLE
fix: add es-update-oersi for old edu-sharig

### DIFF
--- a/ansible/roles/edu-sharing/tasks/common/alfviral.yml
+++ b/ansible/roles/edu-sharing/tasks/common/alfviral.yml
@@ -8,4 +8,4 @@
   command:
     chdir: '{{ alf_home }}/bin'
     cmd: 'java -jar alfresco-mmt.jar install ../amps/{{ antivirus_alfviral_amp_filename | basename }} {{tomcat_home}}/webapps/alfresco.war -verbose -nobackup'
-  when: install_alfviral | default(false) | bool
+  when: old_install_alfviral | default(false) | bool

--- a/ansible/roles/edu-sharing/tasks/common/es_update_oersi.yml
+++ b/ansible/roles/edu-sharing/tasks/common/es_update_oersi.yml
@@ -8,4 +8,4 @@
   command:
     chdir: '{{ alf_home }}/bin'
     cmd: 'java -jar alfresco-mmt.jar install ../amps/{{ es_update_oersi_amp_filename | basename }} {{tomcat_home}}/webapps/alfresco.war -verbose -nobackup'
-  when: activate_es_update_oersi | default(false) | bool
+  when: old_install_es_update_oersi | default(false) | bool

--- a/ansible/roles/edu-sharing/tasks/edu-sharing-old/main.yml
+++ b/ansible/roles/edu-sharing/tasks/edu-sharing-old/main.yml
@@ -14,16 +14,27 @@
     when: alfresco_share_install is defined and alfresco_share_install
   - include: ./common/alfviral.yml 
         alf_amp_destination='{{ alf_home }}/amps/'
-        install_alfviral=true
+        old_install_alfviral=true
     when: install_antivirus is defined and install_antivirus
+  - include: ./common/es_update_oersi.yml 
+        es_amp_destination='{{ alf_home }}/amps/'
+        old_install_es_update_oersi=true
+    when: activate_es_update_oersi is defined and activate_es_update_oersi
     tags:
-      - antivirus
+      - es-update-oersi-old
+      - es-update-oersi
   - include: ./common/add_alviral_to_alfresco_properties.yml 
         alfresco_global_properties_path='{{tomcat_home}}/shared/classes'
     when:  install_antivirus is defined and  install_antivirus
     tags:
     - alfviral
     - antivirus-old
+  - include: ./common/add_es_update_oersi_to_alfresco_properties.yml 
+        alfresco_global_properties_path='{{tomcat_home}}/shared/classes'
+    when:  activate_es_update_oersi is defined and  activate_es_update_oersi    
+    tags:
+      - es-update-oersi-old
+      - es-update-oersi
   - include: ./common/add_mail_config_to_alfresco_properties.yml
       alfresco_global_properties_path='{{tomcat_home}}/shared/classes'
     tags:


### PR DESCRIPTION
Hello @mirjan-hoffmann 

I forget to include the es-update-oersi in the old edu-sharing version.

this pull request will add that, and I also renamed 2 variables, for better readable, and also was a small problem with the update es-update-oersi