### PR TITLE
Configure timezone for repository-service

### DIFF
--- a/ansible/roles/edu-sharing/defaults/main.yml
+++ b/ansible/roles/edu-sharing/defaults/main.yml
@@ -63,6 +63,7 @@ oersi_index: "oer_data"
 
 
 edu_sharing_docker_project_name: "edu_sharing_docker_version"
+edu_sharing_docker_timezone: '{{timezone | default("Europe/Berlin",true)}}'
 
 edu_sharing_environment_variable:
   - key: COMPOSE_PROJECT_NAME

--- a/ansible/roles/edu-sharing/templates/docker-compose.override.yml
+++ b/ansible/roles/edu-sharing/templates/docker-compose.override.yml
@@ -2,6 +2,8 @@ version: "3.7"
 services:
   repository-service:
     image: docker.edu-sharing.com/projects/community/edu_sharing-projects-community-deploy-docker-repository-build-service:{{ edu_version }}-{{ edu_repo_caption }}-custom
+    environment:
+      - TZ={{edu_sharing_docker_timezone}}
     volumes:
       - repository-service-volume-config-node:/opt/bitnami/tomcat/shared/classes/config
       - "repository-service-volume-config-edu-sharing:/opt/bitnami/tomcat/webapps/edu-sharing"


### PR DESCRIPTION
This pull request updates the Docker container configuration to dynamically set the timezone for the **repository-service**. The timezone is now determined based on the **edu_sharing_docker_timezone** variable.