### PR TITLE
Release Version 9.0.0 of edu-sharing with Ansible Task Adjustments

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -2,7 +2,7 @@
 edu_sharing_host: 192.168.98.101
 edu_sharing_domain: '{{edu_sharing_host}}'
 edu_sharing_url: '{{ edu_sharing_protocol | default("http") }}://{{edu_sharing_host}}/edu-sharing'
-edu_version: 8.1.0
+edu_version: 9.0.0
 solr_host: '{{edu_sharing_host}}'
 
 esrender_host: 192.168.98.101

--- a/ansible/roles/edu-connector/tasks/main.yml
+++ b/ansible/roles/edu-connector/tasks/main.yml
@@ -18,10 +18,10 @@
   shell: |
     sg docker -c "docker ps -a --format '{{ '{{' }}.Names{{ '}}' }}' | grep -E '{{edu_connector_docker_project_name}}' | xargs -r docker stop "
 
-- include: install.yml
+- include_tasks: install.yml
   tags: 
     - edu-connector-installation
-- include: register.yml
+- include_tasks: register.yml
   tags: 
     - edu-connector-registration
 

--- a/ansible/roles/edu-sharing-init/vars/versions/9.0.0.yml
+++ b/ansible/roles/edu-sharing-init/vars/versions/9.0.0.yml
@@ -1,0 +1,22 @@
+---
+edu_sharing_archive_url: https://artifacts.edu-sharing.com/repository/maven-remote/org/edu_sharing/edu_sharing-projects-community-deploy-docker-compose/9.0.0/edu_sharing-projects-community-deploy-docker-compose-9.0.0-bin.zip
+
+# In newer versions Edu-sharing may change the deploy commands, if so we can change them here
+# {service} is an variable tha ansible will replace, based on what service we want to execute the action
+edu_sharing_deploy_command: 'sg docker -c "./utils.sh start {service}"'
+edu_sharing_restart_command: 'sg docker -c "./utils.sh restart {service}"'
+# remove docker images from server
+edu_sharing_undeploy_command: 'sg docker -c "./utils.sh stop {service}"'
+edu_sharing_remove_containers_command: |
+     yes | sg docker -c "./utils.sh remove {service}"
+
+# this will remove images,containers and volumes, so be carefully when we use it.
+edu_sharing_purge_all_command: |
+     yes | sg docker -c "./utils.sh purge {service}"
+
+# Edu-sharing backup command
+edu_sharing_backup_command: 'sg docker -c "./utils.sh backup {options}"'
+# Edu-sharing restore command
+edu_sharing_restore_command: 'sg docker -c "./utils.sh restore {options}"'
+
+service_repository_search_solr:  'repository-search-solr'

--- a/ansible/roles/java/tasks/main.yml
+++ b/ansible/roles/java/tasks/main.yml
@@ -10,7 +10,7 @@
     state: present 
     update_cache: yes
 
-- include: get_java_home.yml
+- include_tasks: get_java_home.yml
 
 - name: Set JAVA_HOME if configured.
   template:


### PR DESCRIPTION
This pull request introduces changes for the Release of Version 9.0.0 of edu-sharing. Key updates include:

1.  New Version File Added:
A new file 9.0.0.yml has been created under ansible/roles/edu-sharing-init/vars/versions/. This file defines variables specific to the new 9.0.0 release.

2. Version Number Updated:
The version in ansible/group_vars/all.yml has been updated to 9.0.0 to reflect the new release version.

3. Adjustments to Ansible Tasks:
Changes were made in ansible/roles/java/tasks/main.yml and ansible/roles/edu-connector/tasks/main.yml to fix the deprecation warning related to task inclusion in Ansible. The warning appeared due to a change in Ansible, where the direct use of include was deprecated after May 16, 2023. These tasks have been updated to use include_tasks or import_tasks, as recommended, to ensure continued compatibility with Ansible.


