### PR TITLE
Implement alfresco webscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,5 @@ Each role in the edu-sharing playbook comes with its own detailed documentation,
 - [edu-sharing-splash](ansible/roles/edu-sharing-splash/documentation/README.md): This role handles edu-sharing-splash installation.
 - [edu-sharing-plugin-mongo](ansible/roles/edu-sharing-plugin-mongo/documentation/README.md): This role handles edu-sharing-plugin-mongo.
 - [edu-sharing-notification](ansible/roles/edu-sharing-notification/documentation/README.md): This role handles edu-sharing-notification plugin.
+- [edu-sharing-alfresco-webscripts](ansible/roles/edu-sharing-alfresco-webscripts/documentation/README.md): This role manages custom Alfresco webscripts.
 These documentation files provide detailed instructions and guidelines for using each role effectively.

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -26,6 +26,11 @@ edu_sharing_restore_from_backup: false
 # activate/deactivate es-update-oersi, a alfresco plugin used to update metadata in oersi
 activate_es_update_oersi: false
 
+# Enable/disable Alfresco webscripts management: wrapper script for folder creation and volume mounting support
+# When enabled, creates and manages Alfresco webscripts folder for persistent webscript storage
+# This prevents permission issues when mounting Docker volumes at container startup
+enable_alfresco_webscripts_management: false
+
 apache_conf_servername: # use as apache2 ServerName Directive, if set - see http://httpd.apache.org/docs/2.2/en/mod/core.html#servername
 apache_conf_usecanonicalname: # use as apache2 UseCanonicalName Directive, if set. Example: On - see http://httpd.apache.org/docs/2.2/en/mod/core.html#usecanonicalname
 # Recommended RAM for ClamAV :

--- a/ansible/roles/apache/templates/apache_vhost.conf.j2
+++ b/ansible/roles/apache/templates/apache_vhost.conf.j2
@@ -14,6 +14,10 @@
                 ProxyPass ajp://localhost:8102/share
                 ProxyPassReverse ajp://localhost:8102/share
         </Location>
+        <Location /alfresco>
+                ProxyPass ajp://localhost:8102/alfresco
+                ProxyPassReverse ajp://localhost:8102/alfresco
+        </Location>
          #ProxyPreserveHost On
         <Location /esrender>
               ProxyPass http://localhost:9100/esrender

--- a/ansible/roles/edu-sharing-alfresco-webscripts/defaults/main.yml
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/defaults/main.yml
@@ -1,0 +1,36 @@
+---
+# Default variables for edu-sharing-alfresco-webscripts role
+
+alfresco_webscripts_url: "{{ edu_sharing_protocol | default('http') }}://{{ edu_sharing_host }}/alfresco/service/index"
+
+# List of webscripts to deploy
+# Each item can have:
+#   - src: A single file, folder, or array of files
+#   - dest: Optional destination path inside the webscripts volume (relative to volume root)
+#           If not specified, files are copied to the root of the webscripts volume
+
+webscripts_to_deploy: []
+  # Example: Single file
+  # - src: "files/webscripts/login.get.desc.xml"
+  #   dest: "login"  # Optional: will be placed in {{ repository_service_volume_webscripts }}/login/
+
+  # Example: Folder containing multiple webscripts
+  # - src: "files/webscripts/search-script"
+  #   dest: "search-script"  # Optional: entire folder copied to this destination
+
+  # Example: Multiple individual files
+  # - src:
+  #     - "files/webscripts/script1.json.ftl"
+  #     - "files/webscripts/script1.get.desc.xml"
+  #     - "files/webscripts/script1.get.js"
+  #   dest: "custom/script1"  # Optional: all files copied to this destination
+
+  # Example: File without destination (goes to root)
+  # - src: "files/webscripts/global-script.get.desc.xml"
+  #   # No dest - will be copied to {{ repository_service_volume_webscripts }}/
+
+
+
+
+
+

--- a/ansible/roles/edu-sharing-alfresco-webscripts/documentation/README.md
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/documentation/README.md
@@ -1,0 +1,148 @@
+# Ansible Role: edu-sharing-alfresco-webscripts
+
+The `edu-sharing-alfresco-webscripts` role is responsible for managing custom Alfresco webscripts. This role handles the complete lifecycle of webscripts including cleanup, deployment, and reloading in the Alfresco repository service.
+
+## Implementation
+
+The `edu-sharing-alfresco-webscripts` role is included in the playbook [system.yml](../../../system.yml).
+
+```yaml
+- hosts: edusharing
+  roles:
+    - role: edu-sharing-alfresco-webscripts
+      tags: 
+        - edu-sharing-alfresco-webscripts
+
+```
+
+To run only the `edu-sharing-alfresco-webscripts` role:
+
+```sh
+ansible-playbook -v -i <host> ansible/system.yml --tags "edu-sharing-alfresco-webscripts"
+```
+This will skip other roles and run only the edu-sharing-alfresco-webscripts role.
+
+
+## Role Variables
+
+The `edu-sharing-alfresco-webscripts` role allows you to customize variables according to your requirements. 
+
+Here are the default variables:
+
+```yaml
+---
+# Default variables for edu-sharing-alfresco-webscripts role
+
+alfresco_webscripts_url: "{{ edu_sharing_protocol | default('http') }}://{{ edu_sharing_host }}/alfresco/service/index"
+
+# List of webscripts to deploy
+# Each item can have:
+#   - src: A single file, folder, or array of files
+#   - dest: Optional destination path inside the webscripts volume (relative to volume root)
+#           If not specified, files are copied to the root of the webscripts volume
+
+webscripts_to_deploy: []
+  # Example: Single file
+  # - src: "files/webscripts/login.get.desc.xml"
+  #   dest: "login"  # Optional: will be placed in {{ repository_service_volume_webscripts }}/login/
+
+  # Example: Folder containing multiple webscripts
+  # - src: "files/webscripts/search-script"
+  #   dest: "search-script"  # Optional: entire folder copied to this destination
+
+  # Example: Multiple individual files
+  # - src:
+  #     - "files/webscripts/script1.json.ftl"
+  #     - "files/webscripts/script1.get.desc.xml"
+  #     - "files/webscripts/script1.get.js"
+  #   dest: "custom/script1"  # Optional: all files copied to this destination
+
+  # Example: File without destination (goes to root)
+  # - src: "files/webscripts/global-script.get.desc.xml"
+  #   # No dest - will be copied to {{ repository_service_volume_webscripts }}/
+```
+
+### Variable Description
+
+#### `alfresco_webscripts_url`
+- **Default**: `{{ edu_sharing_protocol | default('http') }}://{{ edu_sharing_host }}/alfresco/service/index`
+- **Description**: The URL endpoint used to reload and register webscripts in Alfresco. This endpoint accepts POST requests with `reset=on` parameter to trigger a full webscripts reload.
+- **Usage**: Internal variable used for webscripts registration. Automatically constructed from `edu_sharing_protocol` and `edu_sharing_host`.
+
+#### `webscripts_to_deploy`
+- **Default**: `[]` (empty list)
+- **Description**: List of webscripts to deploy to the Alfresco repository. Each item can contain single files, folders, or multiple files with optional destination paths.
+- **Structure**: Each item in the list should have:
+  - `src` (required): Source file(s) or folder to deploy (string or list of strings)
+  - `dest` (optional): Destination path relative to the webscripts volume root. If not specified, files are copied to the root of the webscripts volume.
+
+**Examples**:
+
+Single file deployment:
+```yaml
+webscripts_to_deploy:
+  - src: "files/webscripts/login.get.desc.xml"
+    dest: "login"
+```
+
+Entire folder deployment:
+```yaml
+webscripts_to_deploy:
+  - src: "files/webscripts/search-script"
+    dest: "search-script"
+```
+
+Multiple files to same destination:
+```yaml
+webscripts_to_deploy:
+  - src:
+      - "files/webscripts/script1.json.ftl"
+      - "files/webscripts/script1.get.desc.xml"
+      - "files/webscripts/script1.get.js"
+    dest: "custom/script1"
+```
+
+File without destination (goes to root):
+```yaml
+webscripts_to_deploy:
+  - src: "files/webscripts/global-script.get.desc.xml"
+```
+
+## Tasks
+
+The `tasks/` directory contains all the ansible tasks.
+
+- `main.yml`: The main entry task for ansible.
+- `cleanup_webscripts.yml`: Finds and removes all existing webscripts content from the volume and reloads Alfresco.
+- `deploy_webscript.yml`: Copies new webscripts to the designated locations.
+- `register_webscripts.yml`: Reloads and registers all webscripts in Alfresco.
+
+## Examples
+
+### Basic Configuration
+
+```yaml
+webscripts_to_deploy:
+  - src: "files/org/twillo/institution"
+    dest: "org/twillo/institution"
+```
+
+### Multiple Webscripts Deployment
+
+```yaml
+webscripts_to_deploy:
+  # Custom institutional webscripts
+  - src: "files/org/twillo/institution"
+    dest: "org/twillo/institution"
+  
+  # Search enhancement webscripts
+  - src:
+      - "files/webscripts/search.get.desc.xml"
+      - "files/webscripts/search.get.js"
+      - "files/webscripts/search.get.json.ftl"
+    dest: "api/search"
+  
+  # Global utility scripts
+  - src: "files/webscripts/utils"
+    dest: "utils"
+```

--- a/ansible/roles/edu-sharing-alfresco-webscripts/files/org/twillo/greetings/helloworld.get.html.ftl
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/files/org/twillo/greetings/helloworld.get.html.ftl
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hello Greeting</title>
+</head>
+<body>
+    <h1>${greeting}</h1>
+</body>
+</html>

--- a/ansible/roles/edu-sharing-alfresco-webscripts/files/org/twillo/greetings/helloworld.get.js
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/files/org/twillo/greetings/helloworld.get.js
@@ -1,0 +1,41 @@
+/**
+ * Hello Greeting Web Script
+ *
+ * Logic:
+ * - If 'username' parameter is provided, fetch the full name from Alfresco
+ * - If no 'username' is provided, use the currently logged-in user
+ * - Returns the greeting message to the template
+ */
+
+// Get the optional username parameter
+var usernameParam = args["username"];
+var fullName;
+
+// If username is provided, fetch the person's full name from Alfresco
+if (usernameParam) {
+  var person = people.getPerson(usernameParam);
+  if (person) {
+    var firstName = person.properties.firstName || "";
+    var lastName = person.properties.lastName || "";
+    var email = person.properties.email || "";
+    fullName = (firstName + " " + lastName).trim() || usernameParam;
+    if (email) {
+      fullName += " (" + email + ")";
+    }
+  } else {
+    // Username not found, fallback to the parameter itself
+    fullName = usernameParam;
+  }
+} else {
+  // No parameter, use the currently logged-in user
+  var firstName = person.properties.firstName || "";
+  var lastName = person.properties.lastName || "";
+  var email = person.properties.email || "";
+  fullName = (firstName + " " + lastName).trim() || user.name;
+  if (email) {
+    fullName += " (" + email + ")";
+  }
+}
+
+// Construct greeting message
+model.greeting = "Welcome, " + fullName + "!";

--- a/ansible/roles/edu-sharing-alfresco-webscripts/files/org/twillo/greetings/helloworld.get.json.ftl
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/files/org/twillo/greetings/helloworld.get.json.ftl
@@ -1,0 +1,3 @@
+{
+    "greeting": "${greeting?json_string}"
+}

--- a/ansible/roles/edu-sharing-alfresco-webscripts/handlers/main.yml
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/handlers/main.yml
@@ -1,0 +1,18 @@
+---
+# Handlers for edu-sharing-alfresco-webscripts role
+
+- name: reload alfresco webscripts
+  uri:
+    url: "{{ alfresco_webscripts_url }}"
+    method: POST
+    body: "reset=on"
+    user: "{{ alfresco_admin_user | default('admin') }}"
+    password: "{{ alfresco_admin_password | default(alf_password) }}"
+    force_basic_auth: yes
+    status_code: 200
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+  register: webscripts_reload_result
+  failed_when: false
+
+

--- a/ansible/roles/edu-sharing-alfresco-webscripts/tasks/cleanup_webscripts.yml
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/tasks/cleanup_webscripts.yml
@@ -1,0 +1,27 @@
+---
+# Clean up all existing webscripts content
+
+- name: Find all items in webscripts directory
+  find:
+    paths: "{{ repository_volume_webscripts.stdout }}"
+    file_type: any
+    hidden: yes
+  register: webscripts_contents
+  become: true
+  tags: 
+    - edu-sharing-alfresco-webscripts
+    - alfresco-webscripts-management
+    - alfresco-customization
+
+- name: Remove all existing webscripts content
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  become: true
+  loop: "{{ webscripts_contents.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  tags:
+    - edu-sharing-alfresco-webscripts
+    - alfresco-webscripts-management
+    - alfresco-customization

--- a/ansible/roles/edu-sharing-alfresco-webscripts/tasks/deploy_webscript.yml
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/tasks/deploy_webscript.yml
@@ -1,0 +1,16 @@
+---
+# Deploy Alfresco webscripts
+
+- name: Deploy webscripts
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ repository_volume_webscripts.stdout }}{% if item.dest is defined and item.dest != '' %}/{{ item.dest }}{% endif %}/"
+    mode: '0755'
+  become: true
+  loop: "{{ webscripts_to_deploy }}"
+  loop_control:
+    label: "{{ item.src }}"
+  tags:
+    - edu-sharing-alfresco-webscripts
+    - alfresco-webscripts-management
+    - alfresco-customization

--- a/ansible/roles/edu-sharing-alfresco-webscripts/tasks/main.yml
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+# Main tasks for edu-sharing-alfresco-webscripts role
+
+- name: Get the path to the repository service config webscripts volume.
+  shell: |
+    sg docker -c "docker volume inspect --format '{{ '{{' }}.Mountpoint{{ '}}' }}'  $(sg docker -c "docker volume ls -q |grep '_repository-service-volume-webscripts'")"
+  register: repository_volume_webscripts
+  ignore_errors: true
+  tags:
+    - edu-sharing-alfresco-webscripts
+    - alfresco-webscripts-management
+    - alfresco-customization
+
+- name: Clean up existing webscripts
+  include_tasks: cleanup_webscripts.yml
+  when:
+    - repository_volume_webscripts.stdout is defined
+    - repository_volume_webscripts.stdout != ""
+  tags:
+    - edu-sharing-alfresco-webscripts
+    - alfresco-webscripts-management
+    - alfresco-customization
+
+- name: Deploy Alfresco webscripts
+  include_tasks: deploy_webscript.yml
+  when:
+    - repository_volume_webscripts.stdout is defined
+    - repository_volume_webscripts.stdout != ""
+    - enable_alfresco_webscripts_management | default(false)
+    - webscripts_to_deploy is defined
+    - webscripts_to_deploy is not none
+    - webscripts_to_deploy | length > 0
+  tags:
+    - edu-sharing-alfresco-webscripts
+    - alfresco-webscripts-management
+    - alfresco-customization
+
+- name: Register and reload webscripts
+  include_tasks: register_webscripts.yml
+  tags:
+    - edu-sharing-alfresco-webscripts
+    - alfresco-webscripts-management
+    - alfresco-customization

--- a/ansible/roles/edu-sharing-alfresco-webscripts/tasks/register_webscripts.yml
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/tasks/register_webscripts.yml
@@ -1,0 +1,31 @@
+---
+# Register webscripts and reload Alfresco
+
+- name: reload alfresco webscripts
+  uri:
+    url: "{{ alfresco_webscripts_url }}"
+    method: POST
+    body: "reset=on"
+    user: "{{ alfresco_admin_user | default('admin') }}"
+    password: "{{ alfresco_admin_password | default(alf_password) }}"
+    force_basic_auth: yes
+    status_code: 200
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+  register: webscripts_reload_result
+  failed_when: false
+  tags:
+    - edu-sharing-alfresco-webscripts
+    - alfresco-webscripts-management
+    - alfresco-customization
+
+
+
+- name: Display webscripts reload result
+  debug:
+    msg: "Alfresco webscripts reload status: {{ webscripts_reload_result.status | default('failed') }}"
+  when: webscripts_reload_result is defined
+  tags:
+    - edu-sharing-alfresco-webscripts
+    - alfresco-webscripts-management
+    - alfresco-customization

--- a/ansible/roles/edu-sharing-alfresco-webscripts/templates/.gitkeep
+++ b/ansible/roles/edu-sharing-alfresco-webscripts/templates/.gitkeep
@@ -1,0 +1,5 @@
+
+<Location {{edu_sharing_splash_apache_location | default("/edu-splash",true)}}>
+      ProxyPass http://localhost:{{edu_sharing_splash_port | default('8050',true)}}
+      ProxyPassReverse http://localhost:{{edu_sharing_splash_port | default('8050',true)}}
+</Location>

--- a/ansible/roles/edu-sharing-init/templates/Dockerfile_repository-service.j2
+++ b/ansible/roles/edu-sharing-init/templates/Dockerfile_repository-service.j2
@@ -4,3 +4,9 @@ USER worker
 COPY {{amp_file_name}} /opt/alfresco/amps/alfresco/1/{{amp_file_name}}
 
 COPY reinstall.sh /opt/alfresco/bin/reinstall.sh
+
+{% if enable_alfresco_webscripts_management | default(false) %}
+# Alfresco webscripts management: Create directory with proper permissions
+RUN set -eux \
+    && mkdir -p {{ alfresco_webscripts_path | default("/opt/alfresco/tomcat/shared/classes/alfresco/extension/templates/webscripts") }}
+{% endif %}

--- a/ansible/roles/edu-sharing-init/templates/docker-compose.override.yml.j2
+++ b/ansible/roles/edu-sharing-init/templates/docker-compose.override.yml.j2
@@ -10,6 +10,9 @@ services:
       - repository-service-volume-config-plugins:/opt/alfresco/tomcat/shared/classes/config/plugins
       - repository-service-volume-bin-plugins:/opt/alfresco/bin/plugins
       - repository-service-volume-amps:/opt/alfresco/amps
+{% if enable_alfresco_webscripts_management | default(false) %}
+      - repository-service-volume-webscripts:{{ alfresco_webscripts_path | default("/opt/alfresco/tomcat/shared/classes/alfresco/extension/templates/webscripts") }}
+{% endif %}
     
 volumes:
   repository-service-volume-config-edu-sharing:
@@ -17,3 +20,6 @@ volumes:
   repository-service-volume-bin-plugins:
   repository-service-volume-amps:
   repository-service-volume-config-node:
+{% if enable_alfresco_webscripts_management | default(false) %}
+  repository-service-volume-webscripts:
+{% endif %}

--- a/ansible/system.yml
+++ b/ansible/system.yml
@@ -84,6 +84,10 @@
     - role: edu-sharing-shibboleth
       tags:
         - edu-sharing-shibboleth
+    - role: edu-sharing-alfresco-webscripts
+      when: enable_alfresco_webscripts_management | default(false)
+      tags:
+        - edu-sharing-alfresco-webscripts
 
 - hosts: opencast
   roles:


### PR DESCRIPTION
## Feature: Alfresco Webscripts Management

Adds infrastructure and Ansible role for managing custom Alfresco webscripts with persistent Docker volume storage.

### Changes

**Infrastructure (`feat(edu-sharing-init)`)**
- Add `enable_alfresco_webscripts_management` configuration flag
- Create webscripts directory in Dockerfile with proper permissions
- Add Docker volume mount for persistent webscript storage
- Configure Apache reverse proxy for `/alfresco` endpoint
- Include webscripts role in system playbook

**Ansible Role (`feat(edu-sharing-alfresco-webscripts)`)**
- New role for webscripts lifecycle management (cleanup, deploy, register)
- Support deployment of single files, folders, or multiple files
- Automatic webscript registration via Alfresco REST API
- Include example "helloworld" webscript
- Comprehensive documentation with usage examples

### Usage

```yaml
enable_alfresco_webscripts_management: true

webscripts_to_deploy:
  - src: "files/org/twillo/greetings"
    dest: "org/twillo/greetings"